### PR TITLE
Improve performance by moving GetBitmap to another thread, and disable manual GC

### DIFF
--- a/ClaudiaIDE/ClaudiaIDE.cs
+++ b/ClaudiaIDE/ClaudiaIDE.cs
@@ -9,6 +9,7 @@ using ClaudiaIDE.ImageProvider;
 using System.Windows.Media;
 using Microsoft.VisualStudio.PlatformUI;
 using System;
+using System.Threading.Tasks;
 
 namespace ClaudiaIDE
 {
@@ -87,7 +88,7 @@ namespace ClaudiaIDE
             try
             {
                 _dispacher.Invoke(ChangeImage);
-                GC.Collect();
+                //GC.Collect();
             }
             catch
             {
@@ -101,13 +102,13 @@ namespace ClaudiaIDE
             _dispacher.Invoke(ChangeImage);
         }
 
-        private void ChangeImage()
+        private async void ChangeImage()
 		{
 			try
 			{
                 SetCanvasBackground(_setting.ExpandToIDE);
 
-                var newimage = _imageProvider.GetBitmap();
+                var newimage = await _imageProvider.GetBitmap();
                 var opacity = _setting.ExpandToIDE && _isMainWindow ? 0.0 : _setting.Opacity;
 
                 if (_setting.ImageBackgroundType == ImageBackgroundType.Single)

--- a/ClaudiaIDE/ClaudiaIdePackage.cs
+++ b/ClaudiaIDE/ClaudiaIdePackage.cs
@@ -76,19 +76,19 @@ namespace ClaudiaIDE
             try
             {
                 _dispacher.Invoke(ChangeImage);
-                GC.Collect();
+                //GC.Collect();
             }
             catch
             {
             }
         }
 
-        private void ChangeImage()
+        private async void ChangeImage()
         {
             try
             {
                 var rRootGrid = (Grid)_mainWindow.Template.FindName("RootGrid", _mainWindow);
-                var newimage = _imageProvider.GetBitmap();
+                var newimage = await _imageProvider.GetBitmap();
 
                 foreach (UIElement el in rRootGrid.Children)
                 {

--- a/ClaudiaIDE/IImageProvider.cs
+++ b/ClaudiaIDE/IImageProvider.cs
@@ -2,12 +2,13 @@
 using System.Windows.Media.Imaging;
 using ClaudiaIDE.Settings;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace ClaudiaIDE
 {
     public interface IImageProvider
     {
-        BitmapSource GetBitmap();
+        Task<BitmapSource> GetBitmap();
         event EventHandler NewImageAvaliable;
         ImageBackgroundType ProviderType { get; }
     }

--- a/ClaudiaIDE/ImageProvider/SingleImageProvider.cs
+++ b/ClaudiaIDE/ImageProvider/SingleImageProvider.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Windows.Media.Imaging;
 using ClaudiaIDE.Settings;
 using ClaudiaIDE.Helpers;
+using System.Threading.Tasks;
 
 namespace ClaudiaIDE.ImageProvider
 {
@@ -34,18 +35,20 @@ namespace ClaudiaIDE.ImageProvider
         }
 
 
-        public BitmapSource GetBitmap()
+        public async Task<BitmapSource> GetBitmap()
         {
-            if (_setting.ImageStretch == ImageStretch.None && 
+            return await Task.Factory.StartNew(() => {
+                if (_setting.ImageStretch == ImageStretch.None &&
                     (_bitmap.Width != _bitmap.PixelWidth || _bitmap.Height != _bitmap.PixelHeight)
                 )
-            {
-                return Utils.ConvertToDpi96(_bitmap);
-            }
-            else
-            {
-                return _bitmap;
-            }
+                {
+                    return Utils.ConvertToDpi96(_bitmap);
+                }
+                else
+                {
+                    return _bitmap;
+                }
+            });
         }
 
         private void LoadImage()


### PR DESCRIPTION
I have large PNG pictures, and everytime the slideshow changes, I get a second delay to my input, which is interfering the normal process of coding.
This change eliminates the delay most of the time.
I'm not very familiar with C#, so please review this!