### PR TITLE
Remove explicit calls to GC.Collect

### DIFF
--- a/ClaudiaIDE/ClaudiaIDE.cs
+++ b/ClaudiaIDE/ClaudiaIDE.cs
@@ -96,7 +96,6 @@ namespace ClaudiaIDE
                 {
                     await Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                     ChangeImage();
-                    GC.Collect();
                 });
             }
             catch

--- a/ClaudiaIDE/ClaudiaIdePackage.cs
+++ b/ClaudiaIDE/ClaudiaIdePackage.cs
@@ -109,7 +109,6 @@ namespace ClaudiaIDE
                 {
                     await Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                     ChangeImage();
-                    GC.Collect();
                 });
             }
             catch { }


### PR DESCRIPTION
Hey, I'm from the Visual Studio performance team. This extension came up on the radar for introducing UI delays (where VS has become unresponsive) that last over 1 second. These interrupt keyboard and mouse events and make customer's experience with VS a little bit worse with this extension installed.

Here are the numbers just over the past 21 days:

Root Failure | Leaf Failure | Hits That Delayed Keyboard/Mouse | Total Hits | Duration (75th Pct) | Delayed Mouse Clicks | Delayed Key Strokes
-- | -- | -- | -- | -- | -- | -- 
claudiaide.dll!ClaudiaIDE.ClaudiaIDE+<<InvokeChangeImage>b___0>d.MoveNext | claudiaide.dll!ClaudiaIDE.ClaudiaIDE+<<InvokeChangeImage>b___0>d.MoveNext | 181 | 8,074 | 1.50 sec | 114 | 68

These calls to GC.Collect are unneeded and interrupt .NET and Visual Studio algorithms for managing memory in the VS process.

