### PR TITLE
fix load settings on initialize package

### DIFF
--- a/ClaudiaIDE/ClaudiaIDE.csproj
+++ b/ClaudiaIDE/ClaudiaIDE.csproj
@@ -236,7 +236,7 @@
       <Version>16.0.202</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.0.1619-preview1</Version>
+      <Version>17.0.3177-preview3</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/ClaudiaIDE/source.extension.vsixmanifest
+++ b/ClaudiaIDE/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ClaudiaIDE..7442ac19-889b-4699-a817-e6e054877ee3" Version="3.0.0.8" Language="en-US" Publisher="buchizo" />
+        <Identity Id="ClaudiaIDE..7442ac19-889b-4699-a817-e6e054877ee3" Version="3.0.0.9" Language="en-US" Publisher="buchizo" />
         <DisplayName>ClaudiaIDE</DisplayName>
         <Description xml:space="preserve">This extension change the background image of editor.</Description>
         <MoreInfo>https://github.com/buchizo/ClaudiaIDE</MoreInfo>


### PR DESCRIPTION
some issues cause is dead lock when load settings from VS option page on InitializeAsync of ClaudiaIDE. Previous PR remove initialize part, but it not enough. This PR is recover initialize part and change to timing using StartOnIdle.

#90  #91 #93