### PR TITLE
Fix nullref slideshow

### DIFF
--- a/ClaudiaIDE/source.extension.vsixmanifest
+++ b/ClaudiaIDE/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ClaudiaIDE..7442ac19-889b-4699-a817-e6e054877ee3" Version="3.1.0" Language="en-US" Publisher="buchizo" />
+        <Identity Id="ClaudiaIDE..7442ac19-889b-4699-a817-e6e054877ee3" Version="3.1.1" Language="en-US" Publisher="buchizo" />
         <DisplayName>ClaudiaIDE</DisplayName>
         <Description xml:space="preserve">This extension change the background image of editor.</Description>
         <MoreInfo>https://github.com/buchizo/ClaudiaIDE</MoreInfo>

--- a/ClaudiaIDE16/source.extension.vsixmanifest
+++ b/ClaudiaIDE16/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ClaudiaIDE2019.9ab800ef-0cff-4893-bf16-57d58ff53456" Version="3.1.0" Language="en-US" Publisher="k.buchi" />
+        <Identity Id="ClaudiaIDE2019.9ab800ef-0cff-4893-bf16-57d58ff53456" Version="3.1.1" Language="en-US" Publisher="k.buchi" />
         <DisplayName>ClaudiaIDE 2019</DisplayName>
         <Description xml:space="preserve">This extension change the background image of editor.</Description>
         <MoreInfo>https://github.com/buchizo/ClaudiaIDE</MoreInfo>

--- a/Shared/ClaudiaIdePackage.cs
+++ b/Shared/ClaudiaIdePackage.cs
@@ -19,7 +19,7 @@ using Window = System.Windows.Window;
 namespace ClaudiaIDE
 {
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [InstalledProductRegistration("#110", "#112", "3.1.0", IconResourceID = 400)]
+    [InstalledProductRegistration("#110", "#112", "3.1.1", IconResourceID = 400)]
     [ProvideOptionPage(typeof(ClaudiaIdeOptionPageGrid), "ClaudiaIDE", "General", 110, 116, true)]
     [Guid(GuidList.PackageId)]
     [ProvideAutoLoad("{ADFC4E65-0397-11D1-9F4E-00A0C911004F}",

--- a/Shared/ImageProviders/SlideShowImageProvider.cs
+++ b/Shared/ImageProviders/SlideShowImageProvider.cs
@@ -56,6 +56,13 @@ namespace ClaudiaIDE.ImageProviders
 
         public override BitmapSource GetBitmap()
         {
+            if (_imageFiles == null)
+            {
+                _imageFiles = GetImagesFromDirectory();
+                _imageFilesPath = _imageFiles.GetEnumerator();
+                _imageFilesPath.MoveNext();
+                _timer.Restart();
+            }
             var current = _imageFilesPath?.Current;
             if (string.IsNullOrEmpty(current)) return null;
 
@@ -124,6 +131,11 @@ namespace ClaudiaIDE.ImageProviders
 
         protected void ChangeImage()
         {
+            if (_imageFiles == null)
+            {
+                _imageFiles = GetImagesFromDirectory();
+                _imageFilesPath = _imageFiles.GetEnumerator();
+            }
             if (_imageFilesPath.MoveNext())
             {
                 FireImageAvailable();


### PR DESCRIPTION
Issue report from marketplace

> Today update version is not run when open project, type is slideshow, and click next background image throw NullReferenceException, If reset general setting can be normal until next reboot visual studio. (Visual Studio Community 2022 17.3.0)

