### PR TITLE
Fixed MaxWidth and MaxHeight settings for Slideshow

### DIFF
--- a/ClaudiaIDE/source.extension.vsixmanifest
+++ b/ClaudiaIDE/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ClaudiaIDE..7442ac19-889b-4699-a817-e6e054877ee3" Version="3.1.35" Language="en-US" Publisher="buchizo" />
+        <Identity Id="ClaudiaIDE..7442ac19-889b-4699-a817-e6e054877ee3" Version="3.1.36" Language="en-US" Publisher="buchizo" />
         <DisplayName>ClaudiaIDE</DisplayName>
         <Description xml:space="preserve">This extension change the background image of editor.</Description>
         <MoreInfo>https://github.com/buchizo/ClaudiaIDE</MoreInfo>

--- a/ClaudiaIDE16/source.extension.vsixmanifest
+++ b/ClaudiaIDE16/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ClaudiaIDE2019.9ab800ef-0cff-4893-bf16-57d58ff53456" Version="3.1.35" Language="en-US" Publisher="k.buchi" />
+        <Identity Id="ClaudiaIDE2019.9ab800ef-0cff-4893-bf16-57d58ff53456" Version="3.1.36" Language="en-US" Publisher="k.buchi" />
         <DisplayName>ClaudiaIDE 2019</DisplayName>
         <Description xml:space="preserve">This extension change the background image of editor.</Description>
         <MoreInfo>https://github.com/buchizo/ClaudiaIDE</MoreInfo>

--- a/Shared/ImageProviders/SlideShowImageProvider.cs
+++ b/Shared/ImageProviders/SlideShowImageProvider.cs
@@ -96,13 +96,15 @@ namespace ClaudiaIDE.ImageProviders
                     return GetBitmap();
                 }
 
-
                 BitmapSource ret_bitmap = bitmap;
                 if (Setting.ImageStretch == ImageStretch.None)
                 {
                     bitmap = Utils.EnsureMaxWidthHeight(bitmap, Setting.MaxWidth, Setting.MaxHeight);
+
                     if (bitmap.Width != bitmap.PixelWidth || bitmap.Height != bitmap.PixelHeight)
                         ret_bitmap = Utils.ConvertToDpi96(bitmap);
+                    else
+                        ret_bitmap = bitmap;
                 }
 
                 if (Setting.SoftEdgeX > 0 || Setting.SoftEdgeY > 0)


### PR DESCRIPTION
There is a bug that prevents the extension from applying the MaxWidth and MaxHeight properties for the Slideshow type.

**Original, big image (3200x4500), MaxHeight: 0:**

![obraz](https://github.com/buchizo/ClaudiaIDE/assets/8158804/28fb68c9-c06a-4327-85ad-383dd8fa76af)

**Current, MaxHeight: 1200:** (no effect...)

![obraz](https://github.com/buchizo/ClaudiaIDE/assets/8158804/e5d631f5-21db-4f88-b3db-ba0bed78fd0d)

**Fixed, MaxHeight: 1200:**

![obraz](https://github.com/buchizo/ClaudiaIDE/assets/8158804/c93e38d5-3e1b-4b83-8c0d-9ba60f8b71f3)

Fixes #191 
