### PR TITLE
fix transparent controll for GlyphMarginGrid

### DIFF
--- a/ClaudiaIDE/source.extension.vsixmanifest
+++ b/ClaudiaIDE/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ClaudiaIDE..7442ac19-889b-4699-a817-e6e054877ee3" Version="3.1.37" Language="en-US" Publisher="buchizo" />
+        <Identity Id="ClaudiaIDE..7442ac19-889b-4699-a817-e6e054877ee3" Version="3.1.38" Language="en-US" Publisher="buchizo" />
         <DisplayName>ClaudiaIDE</DisplayName>
         <Description xml:space="preserve">This extension change the background image of editor.</Description>
         <MoreInfo>https://github.com/buchizo/ClaudiaIDE</MoreInfo>

--- a/ClaudiaIDE16/source.extension.vsixmanifest
+++ b/ClaudiaIDE16/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ClaudiaIDE2019.9ab800ef-0cff-4893-bf16-57d58ff53456" Version="3.1.37" Language="en-US" Publisher="k.buchi" />
+        <Identity Id="ClaudiaIDE2019.9ab800ef-0cff-4893-bf16-57d58ff53456" Version="3.1.38" Language="en-US" Publisher="k.buchi" />
         <DisplayName>ClaudiaIDE 2019</DisplayName>
         <Description xml:space="preserve">This extension change the background image of editor.</Description>
         <MoreInfo>https://github.com/buchizo/ClaudiaIDE</MoreInfo>

--- a/Shared/ClaudiaIDE.cs
+++ b/Shared/ClaudiaIDE.cs
@@ -563,7 +563,8 @@ namespace ClaudiaIDE
                 var type = c.GetType();
                 if (type == null) continue;
                 if (type.FullName.Equals("System.Windows.Controls.Primitives.Thumb", StringComparison.OrdinalIgnoreCase)) return;
-                if (type.FullName.Equals("Microsoft.VisualStudio.Text.Utilities.ContainerMargin", StringComparison.OrdinalIgnoreCase))
+                if (type.FullName.Equals("Microsoft.VisualStudio.Text.Utilities.ContainerMargin", StringComparison.OrdinalIgnoreCase)
+                    || type.FullName.EndsWith("Microsoft.VisualStudio.Text.Editor.Implementation.GlyphMarginGrid", StringComparison.OrdinalIgnoreCase))
                 {
                     tp.ContentMargin = true;
                 }

--- a/Shared/ClaudiaIdePackage.cs
+++ b/Shared/ClaudiaIdePackage.cs
@@ -21,7 +21,7 @@ using System.Windows.Media.Effects;
 namespace ClaudiaIDE
 {
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [InstalledProductRegistration("#110", "#112", "3.1.37", IconResourceID = 400)]
+    [InstalledProductRegistration("#110", "#112", "3.1.38", IconResourceID = 400)]
     [ProvideOptionPage(typeof(ClaudiaIdeOptionPageGrid), "ClaudiaIDE", "Light theme", 110, 116, true)]
     [ProvideOptionPage(typeof(ClaudiaIdeDarkThemeOptionPageGrid), "ClaudiaIDE", "Dark theme", 110, 117, true)]
     [ProvideOptionPage(typeof(ClaudiaIdeGeneralOptionPageGrid), "ClaudiaIDE", "General", 110, 118, true)]


### PR DESCRIPTION
https://github.com/buchizo/ClaudiaIDE/issues/195

support transparent state of break point bar (GlyphMarginGrid)  in `Is transparent to content margin`