### PR TITLE
Changed WebAPI JSON Key to use a JsonPath.

### DIFF
--- a/ClaudiaIDE/source.extension.vsixmanifest
+++ b/ClaudiaIDE/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ClaudiaIDE..7442ac19-889b-4699-a817-e6e054877ee3" Version="3.1.44" Language="en-US" Publisher="buchizo" />
+        <Identity Id="ClaudiaIDE..7442ac19-889b-4699-a817-e6e054877ee3" Version="3.1.45" Language="en-US" Publisher="buchizo" />
         <DisplayName>ClaudiaIDE</DisplayName>
         <Description xml:space="preserve">This extension change the background image of editor.</Description>
         <MoreInfo>https://github.com/buchizo/ClaudiaIDE</MoreInfo>


### PR DESCRIPTION
Hi :)
The JSON-key for WebAPI can be specified more accurately using [Json Path](https://goessner.net/articles/JsonPath/).

Example:
> API Endpoint: `https://api.waifu.im/search?included_tags=maid&height=>=1500`
> JSON-Key: `$.images[0].url`
> Download Interval: Irrelevant

This still works:
> API Endpoint: `https://api.waifu.pics/sfw/waifu`
> JSON-Key: `url`

Please merge if you see this as an improvement.